### PR TITLE
feat: 适配排序参数的枚举转换

### DIFF
--- a/src/render/schema.ts
+++ b/src/render/schema.ts
@@ -50,7 +50,7 @@ function renderEnumDeclaration(writer: Writer, schema: types.EnumSchema) {
       if (/^-/.test(item)) {
         name = changecase.snakeCase(`${item}Desc`).toUpperCase();;
       }else{
-          name = changecase.snakeCase(item).toUpperCase();
+        name = changecase.snakeCase(item).toUpperCase();
       }
     } else {
       name = `${changecase.snakeCase(schema.name).toUpperCase()}_${item}`;

--- a/src/render/schema.ts
+++ b/src/render/schema.ts
@@ -47,7 +47,11 @@ function renderEnumDeclaration(writer: Writer, schema: types.EnumSchema) {
       if (/^\d/.test(item)) {
         name = `_${item}`;
       }
-      name = changecase.snakeCase(item).toUpperCase();
+      if (/^-/.test(item)) {
+        name = changecase.snakeCase(`${item}Desc`).toUpperCase();;
+      }else{
+          name = changecase.snakeCase(item).toUpperCase();
+      }
     } else {
       name = `${changecase.snakeCase(schema.name).toUpperCase()}_${item}`;
     }


### PR DESCRIPTION
# 提交

适配排序参数的枚举类型

关联的 Issue

- 暂无

## 内容（选填）

因为排序参数的枚举值的特殊性(如: createAt, -createAt), 在转换枚举时会出现重复的Key

## 发布计划（选填）

需要重新发布版本

## 其他（选填）

解决方案是：在检测到枚举值以中横线开头时，在Key的后面补上排序方向Desc，防止重复
